### PR TITLE
fix(notes): update date formatting logic to correctly display 'Today' for the current day

### DIFF
--- a/src/app/notes/notes-content.tsx
+++ b/src/app/notes/notes-content.tsx
@@ -105,7 +105,7 @@ export const NotesPage = () => {
     const diffTime = Math.abs(now.getTime() - date.getTime())
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
 
-    if (diffDays === 1) return 'Today'
+    if (diffDays <= 1) return 'Today'
     if (diffDays === 2) return 'Yesterday'
     if (diffDays <= 7) return `${diffDays - 1} days ago`
 


### PR DESCRIPTION
## Fix date calculation showing negative days

This PR fixes a bug in the `formatDate` function where newly created notes were showing "-1 days ago" instead of "Today". The issue was in the conditional logic that calculated the difference between dates - when `diffDays` was 1 (indicating today), the condition `diffDays <= 7` would execute `${diffDays - 1} days ago`, resulting in "0 days ago" or "-1 days ago". The fix changes the first condition from `diffDays === 1` to `diffDays <= 1` to properly handle same-day notes and edge cases with fractional day differences.